### PR TITLE
Add enum type

### DIFF
--- a/lib/Pheasant/Database/Mysqli/Table.php
+++ b/lib/Pheasant/Database/Mysqli/Table.php
@@ -249,7 +249,7 @@ class Table
      */
     private function _buildSet($data)
     {
-        $columns = '';
+        $columns = [];
 
         foreach($data as $key=>$value)
             $columns[] = sprintf('`%s`=?',$key);

--- a/lib/Pheasant/Types/EnumType.php
+++ b/lib/Pheasant/Types/EnumType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pheasant\Types;
+
+class EnumType extends BaseType
+{
+    private $_enum;
+
+    /**
+     * @constructor
+     */
+    public function __construct($enum = array(), $options=null)
+    {
+        if (empty($enum)) {
+            throw new \Pheasant\Exception("Enum requires at least 1 value, none given.");
+        }
+
+        parent::__construct($options);
+        $this->_enum = $enum;
+    }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::columnSql
+     */
+    public function columnSql($column, $platform)
+    {
+        return $platform->columnSql($column, "enum('" . implode("','", $this->_enum) . "')", $this->options());
+    }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::unmarshal
+     */
+    public function unmarshal($value)
+    {
+        return $value;
+    }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::marshal
+     */
+    public function marshal($value)
+    {
+        if (! in_array($value, $this->_enum) &&
+            ! in_array((int) $value, $this->acceptedIndexes())) {
+            throw new \InvalidArgumentException("Attempting to insert invalid enum value {$value}");
+        }
+        return $value;
+    }
+
+    /**
+     * @return array accepted indexes for an enum
+     */
+    protected function acceptedIndexes()
+    {
+        return array_map(function ($key) {
+            return $key += 1;
+        }, array_keys($this->_enum));
+    }
+}

--- a/tests/Pheasant/Tests/TypesTest.php
+++ b/tests/Pheasant/Tests/TypesTest.php
@@ -103,6 +103,12 @@ class TypesTest extends \Pheasant\Tests\MysqlTestCase
         $this->assertMysqlColumnSql("`test` set('foo','bar') not null", $type);
     }
 
+    public function testEnum()
+    {
+        $type = new Types\EnumType(array('open', 'closed'));
+        $this->assertMysqlColumnSql("`test` enum('open','closed')", $type);
+    }
+
     public function assertMysqlColumnSql($sql, $type)
     {
         $this->assertEquals($type->columnSql('test', new \Pheasant\Database\MysqlPlatform()), $sql);


### PR DESCRIPTION
Strings in Pheasant can have allowed values which emulate an `enum` but a true `enum` in most SQL DBMS products is allowed to be accessed by its index (which would equate to a `const int` in PHP.

It seemed like it would make sense to allow a true `enum` in Pheasant so that databases can keep string labels for specific fields while also allowing an integer to be used as a constant in the application logic (to keep from using 'magic strings').

Thoughts?